### PR TITLE
Synonyms for the Bucket available from within the Bucket class

### DIFF
--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -206,8 +206,6 @@ class Bucket
      */
     public function updateSynonym($id, $synonyms, string $original = null)
     {
-        $url = 'synonyms/' . $id;
-
         $this->deleteSynonym($id);
 
         return $this->createSynonym($original, $synonyms);

--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -186,9 +186,12 @@ class Bucket
         }
 
         $this->params = [
-            'original' => $original,
             'synonyms' => $synonyms
         ];
+
+        if ($original !== null) {
+            $this->params['original'] = $original;
+        }
 
         return Query::execute('synonyms', $this, $this->write_key, 'post');
     }

--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -163,6 +163,67 @@ class Bucket
     }
 
     /**
+     * Retrieve all the bucket's synonyms
+     *
+     * @return NeedletailResult
+     */
+    public function synonyms()
+    {
+        return Query::execute('synonyms', $this, $this->read_key, 'get');
+    }
+
+    /**
+     * Create a synonym
+     *
+     * @param  array|string $synonyms
+     * @param  string|null $original
+     * @return NeedletailResult
+     */
+    public function createSynonym($synonyms, string $original = null)
+    {
+        if ( ! is_array($synonyms) ) {
+            $synonyms = [$synonyms];
+        }
+
+        $this->params = [
+            'original' => $original,
+            'synonyms' => $synonyms
+        ];
+
+        return Query::execute('synonyms', $this, $this->write_key, 'post');
+    }
+
+    /**
+     * Update a synonym
+     *
+     * @param  string $id
+     * @param  array|string $synonyms
+     * @param  string|null $original
+     * @return NeedletailResult
+     */
+    public function updateSynonym($id, $synonyms, string $original = null)
+    {
+        $url = 'synonyms/' . $id;
+
+        $this->deleteSynonym($id);
+
+        return $this->createSynonym($original, $synonyms);
+    }
+
+    /**
+     * Delete a synonym
+     *
+     * @param  $id
+     * @return NeedletailResult
+     */
+    public function deleteSynonym($id)
+    {
+        $url = 'synonyms/' . $id;
+
+        return Query::execute($url, $this, $this->write_key, 'delete');
+    }
+
+    /**
      * Determines whether the buckets exists or not.
      *
      * @return bool

--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -241,7 +241,7 @@ class Bucket
     }
 
     /**
-     * Retrieve the bucket' name.
+     * Retrieve the bucket's name.
      *
      * @return string
      */

--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -219,9 +219,7 @@ class Bucket
      */
     public function deleteSynonym($id)
     {
-        $url = 'synonyms/' . $id;
-
-        return Query::execute($url, $this, $this->write_key, 'delete');
+        return Query::execute("synonyms/{$id}", $this, $this->write_key, 'delete');
     }
 
     /**


### PR DESCRIPTION
This would resolve issue #1.

Note that updating a synonym is done by first deleting the original and creating a new one, since the current version doesn't provide updating by id.