### PR TITLE
Removed type hinting for the document_id parameter when updating or deleting documents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "needletail/needletail-php",
     "description": "A PHP interface for Needletail.",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "keywords": [
         "needletail",
         "php"

--- a/src/Bucket.php
+++ b/src/Bucket.php
@@ -136,11 +136,11 @@ class Bucket
     /**
      * Update an already existing document in the specified bucket.
      *
-     * @param  string $document_id
+     * @param  mixed $document_id
      * @param  array $document
      * @return NeedletailResult
      */
-    public function updateDocument(string $document_id, array $document)
+    public function updateDocument($document_id, array $document)
     {
         $this->params = $document;
 
@@ -152,10 +152,10 @@ class Bucket
     /**
      * Delete a document by its identifier.
      *
-     * @param  string $document_id
+     * @param  mixed $document_id
      * @return NeedletailResult
      */
-    public function deleteDocument(string $document_id)
+    public function deleteDocument($document_id)
     {
         return Query::execute('documents/delete', $this, $this->write_key, 'delete', [
             'x-needletail-document-id' => $document_id


### PR DESCRIPTION
I spoke to @GijsGoudzwaard about this problem; Needletail can accept your own id's (useful for syncing Needletail with your own database) but when you try to update a document all of a sudden your integer needs to be a string.

Included the version bump. If that's not appreciated, let me know!